### PR TITLE
Fix setup.sh to unset PYTHONPATH and exit when no virtualenv

### DIFF
--- a/doc/setup.sh
+++ b/doc/setup.sh
@@ -2,8 +2,10 @@
 
 type virtualenv &>/dev/null || {
   echo "Please install virtualenv" >&2
+  return 1
 }
 
+unset PYTHONPATH
 virtualenv venv
 . venv/bin/activate
 pip install -r requirements.txt


### PR DESCRIPTION
Unset pythonpath is necessary to reset pythonpath after setup.bash in ros.