### PR TITLE
Update documentation repo even if it exists

### DIFF
--- a/doc/conf.py
+++ b/doc/conf.py
@@ -102,9 +102,12 @@ for repo in repos:
     uri = os.path.splitext(repo['git']['uri'])[0]
     version = repo['git']['version'] if repo['git'].has_key('version') else 'master'
     print("wrokin on name:{} uri:{} branch:{}".format(local_name, uri, version))
-    subprocess.call(['git', 'clone', '--depth=1', uri, local_name, '-b', version])
+    if os.path.exists(local_name):
+        subprocess.call(['git', 'fetch', '--all'], cwd=local_name)
+    else:
+        subprocess.call(['git', 'clone', '--depth=1', uri, local_name, '-b', version])
     subprocess.call(['git', 'clean', '-xfd'], cwd=local_name)
-    subprocess.call(['git', 'reset', '--hard'], cwd=local_name)
+    subprocess.call(['git', 'reset', '--hard', 'origin/%s' % version], cwd=local_name)
 
     if "/" not in local_name:
         with open("index.rst", "a") as f:


### PR DESCRIPTION
The documentation in rtd won't be updated because of this without pushing the WIPE button.

```
Running Sphinx v1.3.3
making output directory...
fatal: destination path 'jskeus' already exists and is not an empty directory.
Removing doc/
HEAD is now at 397bc49 Build documents from 7b709c178771b8ce6ef23a2f3c2c0711ab00455b
fatal: destination path 'jsk_common' already exists and is not an empty directory.
Removing doc/jsk_network_tools/
Removing doc/jsk_ros_patch/
Removing doc/jsk_tilt_laser/
```